### PR TITLE
Heroku deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,6 @@
 /.sass-cache
 .travis.yml
 app/bower_components/
-apiKeysAndPasswords.js
 server/config/trainingDocs/
-APIKeysAndPasswords.js
 tempImg/
 APIs.js

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -64,7 +64,8 @@ module.exports = function(grunt) {
     // this task deletes ‘stuff’ - use with caution!
     clean: {
       release: [
-        'app/dist/**/'
+        'app/dist/**/',
+        'tempImg/',
       ]
     },
 

--- a/chrome_ext/background.js
+++ b/chrome_ext/background.js
@@ -37,8 +37,8 @@ var checkAuth = new Promise(function(resolve, reject) {
 function sendBookmark(bkmrkObj) {
 
     //NOTE change this to https://clipr-app-1.herokuapp.com for heroku
-    // var website = "https://clipr-app-1.herokuapp.com";
-    var website = "http://localhost:3000";
+    var website = "https://clipr-app-1.herokuapp.com";
+    // var website = "http://localhost:3000";
     var postUrl = website + "/user/post/storeclip";
 
     //var params = '?url=' + url + '&title=' + title.toString() + '&email=' + email.toString();

--- a/chrome_ext/manifest.json
+++ b/chrome_ext/manifest.json
@@ -13,9 +13,6 @@
     "client_id": "313073444392-hcbme8h90e4m4vef5aqev4q2p0t4nugo.apps.googleusercontent.com",
     "scopes": ["https://www.googleapis.com/auth/plus.login"]
   },
-  "chrome_url_overrides": {
-    "newtab": "home.html"
-  },
   "icons": {
     "16": "apple-icon-precomposed.png",
     "42": "apple-icon-precomposed.png",

--- a/server/config/utils.js
+++ b/server/config/utils.js
@@ -152,7 +152,7 @@ createRelation: function(clip, tag, how, relevance, cb) {
     var url = urlapi.parse(targetUrl);
 
     var hostName = url.hostname;
-    var fileName = 'tempImg/' + hostName + '.png';
+    var fileName = 'tempImg/' + hostName + '.jpg';
 
     // API call to url-to-image module
     return urlImage(targetUrl, fileName, options).then(function() {
@@ -167,7 +167,7 @@ createRelation: function(clip, tag, how, relevance, cb) {
         height: 600,
         x: 0,
         y: 0,
-        format: "png"
+        format: "jpg"
       });
     })
     .catch(function(err) {


### PR DESCRIPTION
- App no longer opens every time a new tab opens
- Delete tempImg folder on build

- Switched captured image format from png to jpg.
-- BIG SAVINGS in terms of image size. I tested on espn.com and with png the image size was 257kb and with jpg the same image was 52 kb!